### PR TITLE
fix(ci): handle multiple version IDs in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,9 +131,16 @@ jobs:
         id: get-version-id
         run: |
           version_id="$(bun wrangler versions list --json | \
-            jq -r '.[] |
-            select(.annotations."workers/tag" == "${{ needs.deploy.outputs.version_tag }}") | .id')"
-          echo "version_id=${version_id}" >> $GITHUB_OUTPUT
+            jq -r 'first(.[] |
+            select(.annotations."workers/tag" == "${{ needs.deploy.outputs.version_tag }}") | .id) // ""')"
+
+          if [ -z "$version_id" ]; then
+            echo "Error: No version found with tag ${{ needs.deploy.outputs.version_tag }}"
+            exit 1
+          fi
+
+          echo "Found version ID: $version_id"
+          echo "version_id=${version_id}" >> "$GITHUB_OUTPUT"
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Fix "Invalid format" error in deploy workflow when getting version ID
- Add proper validation and error handling for version ID retrieval

## Changes
- Add `first()` to jq query to prevent multiple IDs being returned
- Add validation to ensure version ID is found before proceeding  
- Add debug output for better troubleshooting
- Quote `$GITHUB_OUTPUT` variable for shell best practices

## Root Cause
The error occurred when:
1. Multiple versions matched the tag filter, causing newlines in the output
2. Or no versions matched, resulting in an empty value

Both cases caused the "Invalid format" error when writing to `$GITHUB_OUTPUT`.

## Test Plan
- [ ] Verify workflow runs successfully on repository_dispatch event
- [ ] Check that correct version ID is selected and logged
- [ ] Confirm publish step receives valid version ID