### PR TITLE
fix: remove account_id from wrangler.jsonc

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,7 +4,6 @@
 	"main": "dist/_worker.js/index.js",
 	"compatibility_date": "2025-07-12",
 	"compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
-	"account_id": "c400a4d044bf4655006c3245036fdb68",
 	"observability": {
 		"enabled": true
 	},


### PR DESCRIPTION
## 概要

`wrangler.jsonc` からハードコードされた `account_id` を削除しました。

## 変更内容

- `wrangler.jsonc`: `account_id` フィールドを削除（セキュリティ向上のため）

## テストプラン

- [ ] ビルドが正常に完了することを確認
- [ ] デプロイが正常に動作することを確認
