### PR TITLE
refactor(admin): improve save logic with sha updates and toast notifications

### DIFF
--- a/src/pages/admin/_lib/blog-service.ts
+++ b/src/pages/admin/_lib/blog-service.ts
@@ -46,5 +46,8 @@ export const updatePostCore = async ({
 		sha,
 	});
 
-	return { success: true, data: res };
+	return {
+		success: true,
+		sha: res.content?.sha,
+	};
 };

--- a/src/pages/admin/_lib/github/types.ts
+++ b/src/pages/admin/_lib/github/types.ts
@@ -6,10 +6,19 @@ export type GitHubContentItem = {
 	htmlUrl?: string | null;
 };
 
+export type GitHubFileCommitContent = {
+	sha: string;
+	name: string;
+	path: string;
+	html_url?: string | null;
+};
+
 export type GitHubFileCommit = {
-	content?: unknown;
-	commit?: unknown;
-	[key: string]: unknown;
+	content: GitHubFileCommitContent | null;
+	commit: {
+		sha: string;
+		message: string;
+	};
 };
 
 export type UpsertContentParams = {


### PR DESCRIPTION
## Summary
- 保存成功後に sha が更新されない問題を修正し、連続編集時のコンフリクトエラーを防止
- `alert()` を daisyUI のトースト通知に置き換え、UX を改善
- 409 コンフリクトエラー時に「ページを再読み込みしてください」と案内
- `GitHubFileCommit` 型を改善し、`content.sha` を適切に取得できるように

## Test plan
- [ ] admin/edit ページで記事を編集・保存し、トースト通知が表示されることを確認
- [ ] 連続で保存してもエラーが発生しないことを確認
- [ ] ネットワークエラー時にエラートーストが表示されることを確認