### PR TITLE
feat(admin): add image upload support in markdown editor

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -9,6 +9,7 @@ import {
 	createOctokit,
 	getGitHubAccessToken,
 } from "@/pages/admin/_lib/github/client";
+import { createContentClientFromToken } from "@/pages/admin/_lib/github/content";
 
 const updatePostInput = z.object({
 	slug: z.string(),
@@ -53,6 +54,84 @@ export const updatePostHandler = async (
 	}
 };
 
+const ALLOWED_IMAGE_TYPES = [
+	"image/jpeg",
+	"image/png",
+	"image/gif",
+	"image/webp",
+	"image/svg+xml",
+];
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+export const uploadImageHandler = async (
+	formData: FormData,
+	context: ActionAPIContext,
+) => {
+	const accessToken = await getGitHubAccessToken(context.request.headers);
+	if (!accessToken) {
+		throw new ActionError({
+			code: "UNAUTHORIZED",
+			message:
+				"GitHub のアクセストークンを取得できませんでした。再ログインしてください。",
+		});
+	}
+
+	const file = formData.get("image") as File | null;
+	const slug = formData.get("slug") as string | null;
+
+	if (!file || !(file instanceof File)) {
+		throw new ActionError({
+			code: "BAD_REQUEST",
+			message: "画像ファイルが選択されていません。",
+		});
+	}
+
+	if (!slug) {
+		throw new ActionError({
+			code: "BAD_REQUEST",
+			message: "記事のslugが指定されていません。",
+		});
+	}
+
+	if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+		throw new ActionError({
+			code: "BAD_REQUEST",
+			message: `対応していないファイル形式です: ${file.type}`,
+		});
+	}
+
+	if (file.size > MAX_FILE_SIZE) {
+		throw new ActionError({
+			code: "BAD_REQUEST",
+			message: "ファイルサイズが10MBを超えています。",
+		});
+	}
+
+	try {
+		const arrayBuffer = await file.arrayBuffer();
+		const base64Content = Buffer.from(arrayBuffer).toString("base64");
+
+		const contentClient = createContentClientFromToken(accessToken);
+		const path = `${slug}/${file.name}`;
+
+		await contentClient.upsertFile({
+			path,
+			content: base64Content,
+			message: `Upload image: ${file.name}`,
+			isBase64: true,
+		});
+
+		return { filename: file.name, path };
+	} catch (e) {
+		console.error(e);
+		const msg = e instanceof Error ? e.message : "Unknown error";
+		throw new ActionError({
+			code: "INTERNAL_SERVER_ERROR",
+			message: `画像のアップロードに失敗しました: ${msg}`,
+		});
+	}
+};
+
 export const triggerDeployHandler = async (
 	_input: unknown,
 	context: ActionAPIContext,
@@ -89,6 +168,10 @@ export const server = {
 		accept: "json",
 		input: updatePostInput,
 		handler: updatePostHandler,
+	}),
+	uploadImage: defineAction({
+		accept: "form",
+		handler: uploadImageHandler,
 	}),
 	triggerDeploy: defineAction({
 		accept: "json",

--- a/src/pages/admin/_components/EditPost.astro
+++ b/src/pages/admin/_components/EditPost.astro
@@ -5,6 +5,7 @@ import EditDate from "./EditDate.astro";
 import EditDraft from "./EditDraft.astro";
 import EditTags from "./EditTags.astro";
 import EditTitle from "./EditTitle.astro";
+import ImageUploader from "./ImageUploader.astro";
 
 interface Props {
 	slug: string;
@@ -62,6 +63,8 @@ const { slug, initialData } = Astro.props;
 		</div>
 	</details>
 
+	<ImageUploader slug={slug} />
+
 	<textarea
 		id="body"
 		name="body"
@@ -73,7 +76,15 @@ const { slug, initialData } = Astro.props;
 
 <script>
 	import { setupEditPostForm } from "@/pages/admin/_lib/edit-post.client";
+	import { setupImageUploader } from "@/pages/admin/_lib/image-upload.client";
+
 	setupEditPostForm();
+
+	const uploader = document.getElementById("image-uploader");
+	const slug = uploader?.dataset.slug;
+	if (slug) {
+		setupImageUploader("image-uploader", "body", slug);
+	}
 
 	const textarea = document.getElementById("body") as HTMLTextAreaElement;
 	if (textarea) {

--- a/src/pages/admin/_components/ImageUploader.astro
+++ b/src/pages/admin/_components/ImageUploader.astro
@@ -1,0 +1,26 @@
+---
+import { Icon } from "astro-icon/components";
+
+interface Props {
+	slug: string;
+}
+
+const { slug } = Astro.props;
+---
+
+<div id="image-uploader" data-slug={slug} class="mb-2">
+	<div
+		data-drop-zone
+		class="border-base-300 hover:border-base-content/30 flex cursor-pointer items-center gap-2 rounded-lg border-2 border-dashed px-3 py-2 transition-colors"
+	>
+		<Icon name="tabler:photo-up" class="text-base-content/50 size-5 shrink-0" />
+		<span class="text-base-content/50 text-sm">
+			画像をドロップ、貼り付け、または
+			<label class="link cursor-pointer">
+				選択
+				<input type="file" accept="image/*" multiple class="hidden" />
+			</label>
+		</span>
+		<span data-upload-status class="text-info ml-auto hidden text-xs"></span>
+	</div>
+</div>

--- a/src/pages/admin/_lib/github/content.ts
+++ b/src/pages/admin/_lib/github/content.ts
@@ -63,7 +63,8 @@ const upsertFileWithOctokit = async (
 	octokit: Octokit,
 	params: UpsertContentParams,
 ): Promise<GitHubFileCommit> => {
-	const { path, content, message, branch, sha, author, committer } = params;
+	const { path, content, message, branch, sha, author, committer, isBase64 } =
+		params;
 	const resolvedPath = normalizePath(path);
 	const response = await octokit.request(
 		"PUT /repos/{owner}/{repo}/contents/{path}",
@@ -72,7 +73,7 @@ const upsertFileWithOctokit = async (
 			repo: repoName,
 			path: resolvedPath,
 			message,
-			content: toBase64(content),
+			content: isBase64 ? content : toBase64(content),
 			branch,
 			sha,
 			author,

--- a/src/pages/admin/_lib/github/types.ts
+++ b/src/pages/admin/_lib/github/types.ts
@@ -29,6 +29,7 @@ export type UpsertContentParams = {
 	sha?: string; // required when updating existing file
 	author?: { name: string; email: string };
 	committer?: { name: string; email: string };
+	isBase64?: boolean; // true if content is already base64 encoded (e.g., binary files)
 };
 
 export type DeleteContentParams = {

--- a/src/pages/admin/_lib/image-upload.client.ts
+++ b/src/pages/admin/_lib/image-upload.client.ts
@@ -1,0 +1,164 @@
+import { actions } from "astro:actions";
+
+type ToastType = "success" | "error" | "info";
+
+const showToast = (message: string, type: ToastType = "info") => {
+	const existing = document.querySelector(".toast-container");
+	if (existing) existing.remove();
+
+	const container = document.createElement("div");
+	container.className = "toast-container toast toast-top toast-end z-50";
+
+	const alertClass = {
+		success: "alert-success",
+		error: "alert-error",
+		info: "alert-info",
+	}[type];
+
+	container.innerHTML = `<div class="alert ${alertClass} shadow-lg"><span>${message}</span></div>`;
+	document.body.appendChild(container);
+
+	setTimeout(() => container.remove(), 3000);
+};
+
+const insertTextAtCursor = (textarea: HTMLTextAreaElement, text: string) => {
+	const start = textarea.selectionStart;
+	const end = textarea.selectionEnd;
+	const before = textarea.value.substring(0, start);
+	const after = textarea.value.substring(end);
+
+	textarea.value = before + text + after;
+	textarea.selectionStart = textarea.selectionEnd = start + text.length;
+	textarea.focus();
+
+	textarea.dispatchEvent(new Event("input", { bubbles: true }));
+};
+
+const uploadImage = async (
+	file: File,
+	slug: string,
+): Promise<string | null> => {
+	const formData = new FormData();
+	formData.append("image", file);
+	formData.append("slug", slug);
+
+	const { data, error } = await actions.uploadImage(formData);
+
+	if (error) {
+		throw new Error(error.message);
+	}
+
+	return data?.filename ?? null;
+};
+
+export const setupImageUploader = (
+	uploaderId: string,
+	textareaId: string,
+	slug: string,
+) => {
+	const uploader = document.getElementById(uploaderId);
+	const textarea = document.getElementById(
+		textareaId,
+	) as HTMLTextAreaElement | null;
+	const fileInput =
+		uploader?.querySelector<HTMLInputElement>('input[type="file"]');
+	const dropZone = uploader?.querySelector<HTMLElement>("[data-drop-zone]");
+
+	if (!uploader || !textarea || !fileInput) return;
+
+	const handleFiles = async (files: FileList | File[]) => {
+		const fileArray = Array.from(files);
+		if (fileArray.length === 0) return;
+
+		const statusEl = uploader.querySelector<HTMLElement>(
+			"[data-upload-status]",
+		);
+		if (statusEl) {
+			statusEl.textContent = `アップロード中... (0/${fileArray.length})`;
+			statusEl.classList.remove("hidden");
+		}
+
+		let successCount = 0;
+
+		for (const file of fileArray) {
+			try {
+				const filename = await uploadImage(file, slug);
+				if (filename) {
+					const markdown = `![${file.name}](${filename})`;
+					insertTextAtCursor(textarea, markdown + "\n");
+					successCount++;
+				}
+			} catch (e) {
+				const msg = e instanceof Error ? e.message : "Unknown error";
+				showToast(`${file.name}: ${msg}`, "error");
+			}
+
+			if (statusEl) {
+				statusEl.textContent = `アップロード中... (${successCount}/${fileArray.length})`;
+			}
+		}
+
+		if (statusEl) {
+			statusEl.classList.add("hidden");
+		}
+
+		if (successCount > 0) {
+			showToast(`${successCount}件の画像をアップロードしました`, "success");
+		}
+
+		fileInput.value = "";
+	};
+
+	fileInput.addEventListener("change", () => {
+		if (fileInput.files) {
+			handleFiles(fileInput.files);
+		}
+	});
+
+	if (dropZone) {
+		dropZone.addEventListener("dragover", (e) => {
+			e.preventDefault();
+			dropZone.classList.add("border-primary", "bg-base-200");
+		});
+
+		dropZone.addEventListener("dragleave", (e) => {
+			e.preventDefault();
+			dropZone.classList.remove("border-primary", "bg-base-200");
+		});
+
+		dropZone.addEventListener("drop", (e) => {
+			e.preventDefault();
+			dropZone.classList.remove("border-primary", "bg-base-200");
+
+			const files = e.dataTransfer?.files;
+			if (files) {
+				handleFiles(files);
+			}
+		});
+	}
+
+	textarea.addEventListener("paste", (e) => {
+		const items = e.clipboardData?.items;
+		if (!items) return;
+
+		const imageFiles: File[] = [];
+		for (const item of items) {
+			if (item.type.startsWith("image/")) {
+				const file = item.getAsFile();
+				if (file) {
+					const timestamp = Date.now();
+					const ext = file.type.split("/")[1] || "png";
+					const newFile = new File([file], `pasted-${timestamp}.${ext}`, {
+						type: file.type,
+					});
+					imageFiles.push(newFile);
+				}
+			}
+		}
+
+		if (imageFiles.length > 0) {
+			e.preventDefault();
+			handleFiles(imageFiles);
+		}
+	});
+};


### PR DESCRIPTION
## Summary
- admin/edit ページのマークダウンエディタに画像アップロード機能を追加
- ドラッグ&ドロップ、クリップボード貼り付け、ファイル選択に対応
- 画像は GitHub リポジトリ（ojii3/content）にアップロード

## Changes

### 新規ファイル
- `src/pages/admin/_components/ImageUploader.astro` - 画像アップロード UI コンポーネント
- `src/pages/admin/_lib/image-upload.client.ts` - クライアント側のアップロードロジック

### 変更ファイル
- `src/actions/index.ts` - `uploadImage` Server Action を追加
- `src/pages/admin/_lib/github/types.ts` - `UpsertContentParams` に `isBase64` フラグ追加
- `src/pages/admin/_lib/github/content.ts` - バイナリファイル（画像）のアップロード対応
- `src/pages/admin/_components/EditPost.astro` - ImageUploader コンポーネントを統合

## Features
- ✅ ファイル選択ボタンでの画像アップロード
- ✅ ドラッグ&ドロップでの画像アップロード
- ✅ クリップボードからの画像貼り付け（Ctrl+V）
- ✅ 複数画像の同時アップロード
- ✅ アップロード進捗表示
- ✅ `![filename](filename)` をカーソル位置に自動挿入
- ✅ 対応形式: JPEG, PNG, GIF, WebP, SVG
- ✅ 最大ファイルサイズ: 10MB

## Test plan
- [ ] ファイル選択で画像をアップロード
- [ ] ドラッグ&ドロップで画像をアップロード
- [ ] クリップボードから画像を貼り付け
- [ ] 複数画像を同時にアップロード
- [ ] 対応外のファイル形式でエラー表示を確認
- [ ] 10MB以上のファイルでエラー表示を確認
- [ ] プレビューページで画像が表示されることを確認
