### PR TITLE
refactor(admin): 統一Result型の導入とユーティリティの共通化

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -63,6 +63,7 @@ export default defineConfig({
 					"file-off",
 					"home",
 					"logout",
+					"photo-up",
 					"rocket",
 					"search",
 					"settings",

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -22,8 +22,13 @@
     - `_components/` — 管理画面専用コンポーネント（エディタ UI など）。
     - `_layouts/` — 管理画面専用レイアウト（実体は `src/pages/admin/_layouts/AdminLayout.astro`）。
     - `_lib/` — 管理画面用ロジック（認証、GitHub API、編集ロジック）。
+      - `github/content.ts` — GitHub Contents API クライアント（`createContentClient`, `createContentClientFromHeaders`）。
+      - `github/encoding.ts` — Base64 エンコード/デコードユーティリティ。
       - `github/rehype-image-url.ts` — Markdown 内の相対パス画像を GitHub Raw URL に変換する rehype プラグイン。
+      - `ui/toast.ts` — Toast 通知表示ユーティリティ（クライアントサイド）。
   - `api/auth/[...all].ts` — BetterAuth API。
+- `src/lib/`（アプリケーション共通ユーティリティ）
+  - `result.ts` — 統一 Result 型（`Result<T, E>`, `AuthResult<T, E>`）とヘルパー関数。
 - `src/actions/`（Astro 制約でサーバーアクション専用）
   - `index.ts` — `updatePost` サーバーアクション。
 - `src/middleware.ts` — Astro エントリーポイント。実処理は `src/pages/_lib/middleware.ts` に委譲。

--- a/src/lib/result.test.ts
+++ b/src/lib/result.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "bun:test";
+import {
+	err,
+	fromPromise,
+	isUnauthorized,
+	map,
+	mapError,
+	ok,
+	unauthorized,
+} from "./result";
+
+describe("Result型", () => {
+	describe("ok", () => {
+		it("成功結果を作成できる", () => {
+			const result = ok(42);
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toBe(42);
+			}
+		});
+	});
+
+	describe("err", () => {
+		it("失敗結果を作成できる", () => {
+			const result = err("エラーメッセージ");
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error).toBe("エラーメッセージ");
+			}
+		});
+	});
+
+	describe("unauthorized", () => {
+		it("認証エラー結果を作成できる", () => {
+			const result = unauthorized();
+			expect(result.ok).toBe(false);
+			expect(isUnauthorized(result)).toBe(true);
+		});
+	});
+
+	describe("isUnauthorized", () => {
+		it("認証エラーを正しく判定できる", () => {
+			expect(isUnauthorized(unauthorized())).toBe(true);
+			expect(isUnauthorized(ok(42))).toBe(false);
+			expect(isUnauthorized(err("other error"))).toBe(false);
+		});
+	});
+
+	describe("map", () => {
+		it("成功時に値を変換できる", () => {
+			const result = map(ok(2), (x) => x * 3);
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toBe(6);
+			}
+		});
+
+		it("失敗時は変換されない", () => {
+			const result = map(err("error"), (x: number) => x * 3);
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error).toBe("error");
+			}
+		});
+	});
+
+	describe("mapError", () => {
+		it("失敗時にエラーを変換できる", () => {
+			const result = mapError(err("error"), (e) => `wrapped: ${e}`);
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error).toBe("wrapped: error");
+			}
+		});
+
+		it("成功時は変換されない", () => {
+			const result = mapError(ok(42), (e) => `wrapped: ${e}`);
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toBe(42);
+			}
+		});
+	});
+
+	describe("fromPromise", () => {
+		it("成功したPromiseをResultに変換できる", async () => {
+			const result = await fromPromise(Promise.resolve(42));
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toBe(42);
+			}
+		});
+
+		it("失敗したPromiseをResultに変換できる", async () => {
+			const result = await fromPromise(Promise.reject(new Error("failed")));
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error.message).toBe("failed");
+			}
+		});
+
+		it("非ErrorオブジェクトもErrorに変換される", async () => {
+			const result = await fromPromise(Promise.reject("string error"));
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error.message).toBe("string error");
+			}
+		});
+	});
+});

--- a/src/lib/result.ts
+++ b/src/lib/result.ts
@@ -1,0 +1,67 @@
+/**
+ * Result型 - エラーハンドリングを型安全に行うためのユーティリティ
+ *
+ * 使用例:
+ * ```typescript
+ * const result = await fetchData();
+ * if (result.ok) {
+ *   console.log(result.value);
+ * } else {
+ *   console.error(result.error);
+ * }
+ * ```
+ */
+
+/** 成功または失敗を表す基本のResult型 */
+export type Result<T, E = string> =
+	| { ok: true; value: T }
+	| { ok: false; error: E };
+
+/** 認証エラーを含むResult型（admin用） */
+export type AuthResult<T, E = string> =
+	| { ok: true; value: T }
+	| { ok: false; error: E; unauthorized?: false }
+	| { ok: false; error: "UNAUTHORIZED"; unauthorized: true };
+
+/** 成功を表すResultを作成 */
+export const ok = <T>(value: T): Result<T, never> => ({ ok: true, value });
+
+/** 失敗を表すResultを作成 */
+export const err = <E>(error: E): Result<never, E> => ({ ok: false, error });
+
+/** 認証エラーを表すResultを作成 */
+export const unauthorized = (): AuthResult<never, "UNAUTHORIZED"> => ({
+	ok: false,
+	error: "UNAUTHORIZED",
+	unauthorized: true,
+});
+
+/** 認証エラーかどうかを判定 */
+export const isUnauthorized = <T, E>(
+	result: AuthResult<T, E>,
+): result is { ok: false; error: "UNAUTHORIZED"; unauthorized: true } =>
+	!result.ok && "unauthorized" in result && result.unauthorized === true;
+
+/** Result.mapの実装 */
+export const map = <T, U, E>(
+	result: Result<T, E>,
+	fn: (value: T) => U,
+): Result<U, E> => (result.ok ? ok(fn(result.value)) : result);
+
+/** Result.mapErrorの実装 */
+export const mapError = <T, E, F>(
+	result: Result<T, E>,
+	fn: (error: E) => F,
+): Result<T, F> => (result.ok ? result : err(fn(result.error)));
+
+/** Promise<T>をPromise<Result<T, Error>>に変換 */
+export const fromPromise = async <T>(
+	promise: Promise<T>,
+): Promise<Result<T, Error>> => {
+	try {
+		const value = await promise;
+		return ok(value);
+	} catch (e) {
+		return err(e instanceof Error ? e : new Error(String(e)));
+	}
+};

--- a/src/pages/admin/_lib/edit-post.client.ts
+++ b/src/pages/admin/_lib/edit-post.client.ts
@@ -1,30 +1,10 @@
 import { actions } from "astro:actions";
+import { showToast } from "./ui/toast";
 
 type SubmitState = {
 	button?: HTMLButtonElement | null;
 	label?: HTMLElement | null;
 	originalText?: string;
-};
-
-type ToastType = "success" | "error" | "info";
-
-const showToast = (message: string, type: ToastType = "info") => {
-	const existing = document.querySelector(".toast-container");
-	if (existing) existing.remove();
-
-	const container = document.createElement("div");
-	container.className = "toast-container toast toast-top toast-end z-50";
-
-	const alertClass = {
-		success: "alert-success",
-		error: "alert-error",
-		info: "alert-info",
-	}[type];
-
-	container.innerHTML = `<div class="alert ${alertClass} shadow-lg"><span>${message}</span></div>`;
-	document.body.appendChild(container);
-
-	setTimeout(() => container.remove(), 3000);
 };
 
 const parseTags = (value: FormDataEntryValue | null) => {

--- a/src/pages/admin/_lib/github/encoding.ts
+++ b/src/pages/admin/_lib/github/encoding.ts
@@ -1,0 +1,32 @@
+/**
+ * Base64エンコード/デコードのユーティリティ
+ * Node.js (Buffer) とブラウザ (TextEncoder + btoa) の両方に対応
+ */
+
+/**
+ * UTF-8文字列をBase64にエンコード
+ */
+export const encodeBase64 = (content: string): string => {
+	if (typeof Buffer !== "undefined") {
+		return Buffer.from(content, "utf8").toString("base64");
+	}
+	const encoded = new TextEncoder().encode(content);
+	let binary = "";
+	for (const byte of encoded) binary += String.fromCharCode(byte);
+	return btoa(binary);
+};
+
+/**
+ * Base64文字列をUTF-8にデコード
+ */
+export const decodeBase64 = (content: string): string => {
+	if (typeof Buffer !== "undefined") {
+		return Buffer.from(content, "base64").toString("utf8");
+	}
+	const binary = atob(content);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i += 1) {
+		bytes[i] = binary.charCodeAt(i);
+	}
+	return new TextDecoder().decode(bytes);
+};

--- a/src/pages/admin/_lib/github/index.ts
+++ b/src/pages/admin/_lib/github/index.ts
@@ -2,6 +2,7 @@ export { repoLabel } from "./client";
 export {
 	type ContentClient,
 	createContentClient,
+	createContentClientFromHeaders,
 	createContentClientFromToken,
 } from "./content";
 export { githubLiveLoader } from "./live-content-loader";

--- a/src/pages/admin/_lib/image-upload.client.ts
+++ b/src/pages/admin/_lib/image-upload.client.ts
@@ -1,25 +1,5 @@
 import { actions } from "astro:actions";
-
-type ToastType = "success" | "error" | "info";
-
-const showToast = (message: string, type: ToastType = "info") => {
-	const existing = document.querySelector(".toast-container");
-	if (existing) existing.remove();
-
-	const container = document.createElement("div");
-	container.className = "toast-container toast toast-top toast-end z-50";
-
-	const alertClass = {
-		success: "alert-success",
-		error: "alert-error",
-		info: "alert-info",
-	}[type];
-
-	container.innerHTML = `<div class="alert ${alertClass} shadow-lg"><span>${message}</span></div>`;
-	document.body.appendChild(container);
-
-	setTimeout(() => container.remove(), 3000);
-};
+import { showError, showSuccess } from "./ui/toast";
 
 const insertTextAtCursor = (textarea: HTMLTextAreaElement, text: string) => {
 	const start = textarea.selectionStart;
@@ -90,7 +70,7 @@ export const setupImageUploader = (
 				}
 			} catch (e) {
 				const msg = e instanceof Error ? e.message : "Unknown error";
-				showToast(`${file.name}: ${msg}`, "error");
+				showError(`${file.name}: ${msg}`);
 			}
 
 			if (statusEl) {
@@ -103,7 +83,7 @@ export const setupImageUploader = (
 		}
 
 		if (successCount > 0) {
-			showToast(`${successCount}件の画像をアップロードしました`, "success");
+			showSuccess(`${successCount}件の画像をアップロードしました`);
 		}
 
 		fileInput.value = "";

--- a/src/pages/admin/_lib/load-content-listing.ts
+++ b/src/pages/admin/_lib/load-content-listing.ts
@@ -1,11 +1,16 @@
+import type { Result } from "@/lib/result";
+import { err, ok } from "@/lib/result";
 import {
-	createContentClient,
+	createContentClientFromHeaders,
 	type GitHubContentItem,
 } from "@/pages/admin/_lib/github";
 
-export type ContentListingResult =
-	| { status: "ok"; entries: GitHubContentItem[]; fetchedAt: string }
-	| { status: "error"; message: string };
+export type ContentListing = {
+	entries: GitHubContentItem[];
+	fetchedAt: string;
+};
+
+export type ContentListingResult = Result<ContentListing>;
 
 // YYYY-MM-DD-n format
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}-\d+$/;
@@ -14,7 +19,7 @@ export const loadContentListing = async (
 	headers: Headers,
 ): Promise<ContentListingResult> => {
 	try {
-		const client = await createContentClient(headers);
+		const client = await createContentClientFromHeaders(headers);
 		const listing = await client.listRepoPath("");
 
 		// Filter for directories matching the date pattern
@@ -22,14 +27,13 @@ export const loadContentListing = async (
 			.filter((item) => item.type === "dir" && DATE_PATTERN.test(item.name))
 			.sort((a, b) => b.name.localeCompare(a.name)); // Sort by date descending
 
-		return {
-			status: "ok",
+		return ok({
 			entries: filteredEntries,
 			fetchedAt: new Date().toISOString(),
-		};
+		});
 	} catch (error) {
 		const message =
 			error instanceof Error ? error.message : "未知のエラーが発生しました。";
-		return { status: "error", message };
+		return err(message);
 	}
 };

--- a/src/pages/admin/_lib/types.ts
+++ b/src/pages/admin/_lib/types.ts
@@ -1,3 +1,5 @@
+import type { AuthResult } from "@/lib/result";
+
 export type EditableFrontmatter = {
 	title?: string;
 	date?: string | Date;
@@ -11,7 +13,5 @@ export type EditablePost = {
 	sha: string;
 };
 
-export type LoadEditablePostResult =
-	| { status: "ok"; post: EditablePost }
-	| { status: "unauthorized" }
-	| { status: "error"; message: string };
+/** 記事読み込みの結果型 */
+export type LoadEditablePostResult = AuthResult<EditablePost>;

--- a/src/pages/admin/_lib/ui/toast.ts
+++ b/src/pages/admin/_lib/ui/toast.ts
@@ -1,0 +1,55 @@
+/**
+ * Toast通知を表示するためのユーティリティ（クライアントサイド専用）
+ */
+
+export type ToastType = "success" | "error" | "info";
+
+export interface ToastOptions {
+	duration?: number;
+}
+
+const DEFAULT_DURATION = 3000;
+const CONTAINER_CLASS = "toast-container";
+
+const alertClassMap: Record<ToastType, string> = {
+	success: "alert-success",
+	error: "alert-error",
+	info: "alert-info",
+};
+
+/**
+ * Toast通知を表示
+ */
+export const showToast = (
+	message: string,
+	type: ToastType = "info",
+	options: ToastOptions = {},
+) => {
+	const { duration = DEFAULT_DURATION } = options;
+
+	// 既存のトーストを削除
+	const existing = document.querySelector(`.${CONTAINER_CLASS}`);
+	if (existing) existing.remove();
+
+	const container = document.createElement("div");
+	container.className = `${CONTAINER_CLASS} toast toast-top toast-end z-50`;
+
+	const alertClass = alertClassMap[type];
+	container.innerHTML = `<div class="alert ${alertClass} shadow-lg"><span>${message}</span></div>`;
+
+	document.body.appendChild(container);
+
+	setTimeout(() => container.remove(), duration);
+};
+
+/** 成功通知を表示 */
+export const showSuccess = (message: string, options?: ToastOptions) =>
+	showToast(message, "success", options);
+
+/** エラー通知を表示 */
+export const showError = (message: string, options?: ToastOptions) =>
+	showToast(message, "error", options);
+
+/** 情報通知を表示 */
+export const showInfo = (message: string, options?: ToastOptions) =>
+	showToast(message, "info", options);

--- a/src/pages/admin/edit/[slug].astro
+++ b/src/pages/admin/edit/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import { Icon } from "astro-icon/components";
+import { isUnauthorized } from "@/lib/result";
 import { loadEditablePost } from "@/pages/admin/_lib/load-editable-post";
 import type { EditablePost } from "@/pages/admin/_lib/types";
 import EditPost from "../_components/EditPost.astro";
@@ -18,16 +19,14 @@ let errorMsg = "";
 
 const loadResult = await loadEditablePost(slug, Astro.request.headers);
 
-if (loadResult.status === "unauthorized") {
+if (isUnauthorized(loadResult)) {
 	return Astro.redirect("/login");
 }
 
-if (loadResult.status === "error") {
-	errorMsg = loadResult.message;
-}
-
-if (loadResult.status === "ok") {
-	postData = loadResult.post;
+if (!loadResult.ok) {
+	errorMsg = loadResult.error;
+} else {
+	postData = loadResult.value;
 }
 ---
 

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -15,13 +15,13 @@ const contentResult = await loadContentListing(Astro.request.headers);
 		<AdminDashboardHeader />
 
 		{
-			contentResult.status === "error" ? (
+			!contentResult.ok ? (
 				<div class="bg-error/10 flex items-center gap-3 rounded-xl p-3 text-sm">
 					<Icon name="tabler:alert-circle" class="text-error size-5 shrink-0" />
-					<span class="text-error">{contentResult.message}</span>
+					<span class="text-error">{contentResult.error}</span>
 				</div>
 			) : (
-				<ContentTable entries={contentResult.entries} />
+				<ContentTable entries={contentResult.value.entries} />
 			)
 		}
 	</main>


### PR DESCRIPTION
## Summary

- 統一 Result 型 (`Result<T, E>`, `AuthResult<T, E>`) を `src/lib/result.ts` に追加
- Toast 通知を `src/pages/admin/_lib/ui/toast.ts` に共通化
- Base64 処理を `src/pages/admin/_lib/github/encoding.ts` に抽出
- ContentClient ファクトリ関数を統一 (`createContentClient`, `createContentClientFromHeaders`)
- admin ページを新しい Result 型パターンに移行

## 変更点

### 新規ファイル
| ファイル | 説明 |
|---------|------|
| `src/lib/result.ts` | 統一 Result 型とヘルパー関数 |
| `src/lib/result.test.ts` | Result 型のユニットテスト |
| `src/pages/admin/_lib/ui/toast.ts` | Toast 共通モジュール |
| `src/pages/admin/_lib/github/encoding.ts` | Base64 エンコード/デコード |

### 変更ファイル
- `github/content.ts` - encoding.ts への委譲、ファクトリ統一
- `_lib/types.ts` - Result 型への移行
- `_lib/load-editable-post.ts` - 新 Result 型使用
- `_lib/load-content-listing.ts` - 新 Result 型使用
- `_lib/edit-post.client.ts` - Toast 共通化
- `_lib/image-upload.client.ts` - Toast 共通化
- `src/AGENTS.md` - 新モジュールの説明追加

## Test plan
- [x] `bun test` - 22 tests passed
- [x] `bun format` - Fixed 5 files
- [x] `bun typecheck` - 0 errors